### PR TITLE
bugfix: correctly switch back to active window when creating minimap window

### DIFF
--- a/minimap.el
+++ b/minimap.el
@@ -358,7 +358,7 @@ when you enter a buffer which is not derived from
       (set-window-dedicated-p nil t))
     (prog1
 	(selected-window)
-      (other-window 1))))
+      (other-window -1))))
 
 (defun minimap-setup-hooks (&optional remove)
   "Hook minimap into other modes.


### PR DESCRIPTION
The bug is most easily recreated by opening two windows with minimap enabled for one and not for the other and then switching between them.
