### PR TITLE
(minimap-new-minimap): Add mouse pointer property.

### DIFF
--- a/minimap.el
+++ b/minimap.el
@@ -436,6 +436,10 @@ Re-use already existing minimap window if possible."
       (setq minimap-base-overlay (make-overlay (point-min) (point-max) nil t t))
       (overlay-put minimap-base-overlay 'face 'minimap-font-face)
       (overlay-put minimap-base-overlay 'priority 1)
+      ;; Add the hand mouse pointer to visible text. It doesn’t seem
+      ;; possible to set the mouse cursor when there’s no text. See
+      ;; `void-text-area-pointer'.
+      (overlay-put minimap-base-overlay 'pointer 'hand)
       (when minimap-tag-only
 	(overlay-put minimap-base-overlay 'face
       		     `(:inherit minimap-font-face


### PR DESCRIPTION
A mouse pointer was added with `minimap-base-overlay` when `minimap-new-minimap` is called.

With a long investigation, it doesn't seem possible to change the pointer where we can't select text (after the new line). The only method is to change the `void-text-area-pointer` variable defined in C source code that is global to the frame.

An other way would be to fill with blank space until the minimap window-width.